### PR TITLE
Updated Svg Package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   equatable: ^2.0.5
-  flutter_svg: ^1.0.2
+  flutter_svg: ^2.0.5
 
 dev_dependencies:
 


### PR DESCRIPTION
Issue :

 Because every version of book_my_seat depends on flutter_svg ^1.0.2 and blubrain depends on flutter_svg ^2.0.5, book_my_seat is forbidden.
So, because blubrain depends on book_my_seat any, version solving failed.

Fix : Updated Flutter Svg Package